### PR TITLE
Adapt parsing Bagit Profile due to specification.

### DIFF
--- a/src/main/java/com/github/jscancella/conformance/profile/BagInfoRequirement.java
+++ b/src/main/java/com/github/jscancella/conformance/profile/BagInfoRequirement.java
@@ -5,13 +5,17 @@ import java.util.List;
 import java.util.Objects;
 
 /**
- * This class is used to define elements in a bag-info.txt file used by a {@link BagitProfile}.
+ * This class is used to define elements in a bag-info.txt file used by a
+ * {@link BagitProfile}. Due to specification in version 1.1.0 all entries are
+ * required=false and repeatable=true by default. See Bag-Info
+ * {@link https://github.com/bagit-profiles/bagit-profiles-specification/tree/1.1.0#implementation-details}
  */
 public class BagInfoRequirement {
-  private boolean required = false;
+
+  private boolean required; // false by default;
   private List<String> acceptableValues = new ArrayList<>();
   private boolean repeatable = true;
-  
+
   @Override
   public boolean equals(final Object other) {
     if (!(other instanceof BagInfoRequirement)) {
@@ -19,8 +23,8 @@ public class BagInfoRequirement {
     }
     final BagInfoRequirement castOther = (BagInfoRequirement) other;
     return Objects.equals(required, castOther.required)
-        && Objects.equals(acceptableValues, castOther.acceptableValues)
-        && Objects.equals(repeatable, castOther.repeatable);
+            && Objects.equals(acceptableValues, castOther.acceptableValues)
+            && Objects.equals(repeatable, castOther.repeatable);
   }
 
   @Override
@@ -28,51 +32,66 @@ public class BagInfoRequirement {
     return Objects.hash(required, acceptableValues, repeatable);
   }
 
-  public BagInfoRequirement(){
-    //intentionally left empty
-  }
-  
   /**
-   * Constructs a new BagInfoRequirement setting {@link #repeatable} to true (default).
+   * Constructs a new BagInfoRequirement setting {@link #repeatable} to true
+   * (default) and {@link #required} to false (default).
+   *
    * @param required Indicates whether or not the tag is required.
    * @param acceptableValues List of acceptable values.
    */
-  public BagInfoRequirement(final boolean required, final List<String> acceptableValues){
+  public BagInfoRequirement() {
+    //intentionally left empty
+  }
+
+  /**
+   * Constructs a new BagInfoRequirement setting {@link #repeatable} to true
+   * (default).
+   *
+   * @param required Indicates whether or not the tag is required.
+   * @param acceptableValues List of acceptable values.
+   */
+  public BagInfoRequirement(final boolean required, final List<String> acceptableValues) {
     this(required, acceptableValues, true);
   }
-  
+
   /**
    * Constructs a new BagInfoRequirement.
+   *
    * @param required Indicates whether or not the tag is required.
    * @param acceptableValues List of acceptable values.
    * @param repeatable Indicates whether or not the tag is repeatable.
    */
-  public BagInfoRequirement(final boolean required, final List<String> acceptableValues, final boolean repeatable){
+  public BagInfoRequirement(final boolean required, final List<String> acceptableValues, final boolean repeatable) {
     this.required = required;
     this.acceptableValues = acceptableValues;
     this.repeatable = repeatable;
   }
-  
+
   @Override
   public String toString() {
     return "[required=" + required + ", acceptableValues=" + acceptableValues + ", repeatable=" + repeatable + "]";
   }
-  
+
   public boolean isRequired() {
     return required;
   }
+
   public void setRequired(final boolean required) {
     this.required = required;
   }
+
   public List<String> getAcceptableValues() {
     return acceptableValues;
   }
+
   public void setAcceptableValues(final List<String> acceptableValues) {
     this.acceptableValues = acceptableValues;
   }
+
   public boolean isRepeatable() {
     return repeatable;
   }
+
   public void setRepeatable(final boolean repeatable) {
     this.repeatable = repeatable;
   }

--- a/src/main/java/com/github/jscancella/conformance/profile/BagInfoRequirement.java
+++ b/src/main/java/com/github/jscancella/conformance/profile/BagInfoRequirement.java
@@ -7,8 +7,8 @@ import java.util.Objects;
 /**
  * This class is used to define elements in a bag-info.txt file used by a
  * {@link BagitProfile}. Due to specification in version 1.1.0 all entries are
- * required=false and repeatable=true by default. See Bag-Info
- * {@link https://github.com/bagit-profiles/bagit-profiles-specification/tree/1.1.0#implementation-details}
+ * required=false and repeatable=true by default. 
+ * @see <a href="https://github.com/bagit-profiles/bagit-profiles-specification/tree/1.1.0#implementation-details">BagIt Profiles Specification</a>
  */
 public class BagInfoRequirement {
 
@@ -35,9 +35,6 @@ public class BagInfoRequirement {
   /**
    * Constructs a new BagInfoRequirement setting {@link #repeatable} to true
    * (default) and {@link #required} to false (default).
-   *
-   * @param required Indicates whether or not the tag is required.
-   * @param acceptableValues List of acceptable values.
    */
   public BagInfoRequirement() {
     //intentionally left empty

--- a/src/main/java/com/github/jscancella/conformance/profile/BagInfoRequirement.java
+++ b/src/main/java/com/github/jscancella/conformance/profile/BagInfoRequirement.java
@@ -8,9 +8,9 @@ import java.util.Objects;
  * This class is used to define elements in a bag-info.txt file used by a {@link BagitProfile}.
  */
 public class BagInfoRequirement {
-  private boolean required;
+  private boolean required = false;
   private List<String> acceptableValues = new ArrayList<>();
-  private boolean repeatable;
+  private boolean repeatable = true;
   
   @Override
   public boolean equals(final Object other) {
@@ -32,9 +32,25 @@ public class BagInfoRequirement {
     //intentionally left empty
   }
   
+  /**
+   * Constructs a new BagInfoRequirement setting {@link #repeatable} to true (default).
+   * @param required Indicates whether or not the tag is required.
+   * @param acceptableValues List of acceptable values.
+   */
   public BagInfoRequirement(final boolean required, final List<String> acceptableValues){
+    this(required, acceptableValues, true);
+  }
+  
+  /**
+   * Constructs a new BagInfoRequirement.
+   * @param required Indicates whether or not the tag is required.
+   * @param acceptableValues List of acceptable values.
+   * @param repeatable Indicates whether or not the tag is repeatable.
+   */
+  public BagInfoRequirement(final boolean required, final List<String> acceptableValues, final boolean repeatable){
     this.required = required;
     this.acceptableValues = acceptableValues;
+    this.repeatable = repeatable;
   }
   
   @Override

--- a/src/main/java/com/github/jscancella/conformance/profile/BagitProfile.java
+++ b/src/main/java/com/github/jscancella/conformance/profile/BagitProfile.java
@@ -17,6 +17,7 @@ public class BagitProfile {
   private String externalDescription = "";
   private String contactName = "";
   private String contactEmail = "";
+  private String contactPhone = "";
   private String version = "";
   
   private Map<String, BagInfoRequirement> bagInfoRequirements = new HashMap<>();
@@ -39,6 +40,7 @@ public class BagitProfile {
         && Objects.equals(sourceOrganization, castOther.sourceOrganization)
         && Objects.equals(externalDescription, castOther.externalDescription)
         && Objects.equals(contactName, castOther.contactName) && Objects.equals(contactEmail, castOther.contactEmail)
+        && Objects.equals(contactPhone, castOther.contactPhone)
         && Objects.equals(version, castOther.version)
         && Objects.equals(bagInfoRequirements, castOther.bagInfoRequirements)
         && Objects.equals(manifestTypesRequired, castOther.manifestTypesRequired)
@@ -51,7 +53,7 @@ public class BagitProfile {
   }
   @Override
   public int hashCode() {
-    return Objects.hash(bagitProfileIdentifier, sourceOrganization, externalDescription, contactName, contactEmail,
+    return Objects.hash(bagitProfileIdentifier, sourceOrganization, externalDescription, contactName, contactEmail, contactPhone,
         version, bagInfoRequirements, manifestTypesRequired, fetchFileAllowed, serialization,
         acceptableMIMESerializationTypes, acceptableBagitVersions, tagManifestTypesRequired, tagFilesRequired);
   }
@@ -59,7 +61,7 @@ public class BagitProfile {
   public String toString() {
     return "BagitProfile [bagitProfileIdentifier=" + bagitProfileIdentifier + ", sourceOrganization="
         + sourceOrganization + ", externalDescription=" + externalDescription + ", contactName=" + contactName
-        + ", contactEmail=" + contactEmail + ", version=" + version + ", bagInfoRequirements=" + bagInfoRequirements
+        + ", contactEmail=" + contactEmail + ", contactPhone=" + contactPhone + ", version=" + version + ", bagInfoRequirements=" + bagInfoRequirements
         + ", manifestTypesRequired=" + manifestTypesRequired + ", fetchFileAllowed=" + fetchFileAllowed
         + ", serialization=" + serialization + ", acceptableMIMESerializationTypes=" + acceptableMIMESerializationTypes
         + ", acceptableBagitVersions=" + acceptableBagitVersions + ", tagManifestTypesRequired="
@@ -143,6 +145,12 @@ public class BagitProfile {
   }
   public void setContactEmail(final String contactEmail) {
     this.contactEmail = contactEmail;
+  }
+  public String getContactPhone() {
+    return contactPhone;
+  }
+  public void setContactPhone(final String contactPhone) {
+    this.contactPhone = contactPhone;
   }
   public String getVersion() {
     return version;

--- a/src/main/java/com/github/jscancella/conformance/profile/BagitProfileDeserializer.java
+++ b/src/main/java/com/github/jscancella/conformance/profile/BagitProfileDeserializer.java
@@ -72,8 +72,8 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
   }
 
   /**
-   * Parse required tags due to specification defined at
-   * {@link https://github.com/bagit-profiles/bagit-profiles}
+   * Parse required tags due to specification version 1.1.0 defined at
+   * {@link https://github.com/bagit-profiles/bagit-profiles-specification/tree/1.1.0}
    * Note: If one of the tags is missing, a NullPointerException is thrown.
    *
    * @param bagitProfileInfoNode Root node of the bagit profile info section.
@@ -84,7 +84,7 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
     
     
     // Read required tags
-    // due to specification defined at https://github.com/bagit-profiles/bagit-profiles
+    // due to specification defined at https://github.com/bagit-profiles/bagit-profiles-specification/tree/1.1.0
     final String profileIdentifier = bagitProfileInfoNode.get("BagIt-Profile-Identifier").asText();
     logger.debug(messages.getString("identifier"), profileIdentifier);
     profile.setBagitProfileIdentifier(profileIdentifier);
@@ -103,8 +103,8 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
   }
 
   /**
-   * Parse optional tags due to specification defined at
-   * {@link https://github.com/bagit-profiles/bagit-profiles}
+   * Parse optional tags due to examples at specification version 1.1.0 defined at
+   * {@link https://github.com/bagit-profiles/bagit-profiles-specification/tree/1.1.0}
    *
    * @param bagitProfileInfoNode Root node of the bagit profile info section.
    * @param profile Representation of bagit profile .
@@ -133,7 +133,11 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
       profile.setContactPhone(contactPhone);
     }
   }
-  
+  /**
+   * Parse Bag Info section of profile.
+   * @param rootNode Root node of the profile.
+   * @return Map containing all entries of the Bag-Info node.
+   */
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
   private static Map<String, BagInfoRequirement> parseBagInfo(final JsonNode rootNode){
     final JsonNode bagInfoNode = rootNode.get("Bag-Info");
@@ -146,12 +150,12 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
       final Entry<String, JsonNode> node = nodes.next();
       
       final BagInfoRequirement entry = new BagInfoRequirement();
-      // due to specification required is false by default.
+
       final JsonNode requiredNode = node.getValue().get("required");
       if (requiredNode != null) {
         entry.setRequired(requiredNode.asBoolean());
       }
-      // due to specification required is false by default.
+
       final JsonNode repeatableNode = node.getValue().get("repeatable");
       if (repeatableNode != null) {
         entry.setRepeatable(repeatableNode.asBoolean());

--- a/src/main/java/com/github/jscancella/conformance/profile/BagitProfileDeserializer.java
+++ b/src/main/java/com/github/jscancella/conformance/profile/BagitProfileDeserializer.java
@@ -64,9 +64,27 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
   }
   
   private static void parseBagitProfileInfo(final JsonNode node, final BagitProfile profile){
-    final JsonNode bagitProfileInfoNode = node.get("BagIt-Profile-Info");
     logger.debug(messages.getString("parsing_bagit_profile_info_section"));
+
+    final JsonNode bagitProfileInfoNode = node.get("BagIt-Profile-Info");
+    parseMandatoryTagsOfBagitProfileInfo(bagitProfileInfoNode, profile);
+    parseOptionalTagsOfBagitProfileInfo(bagitProfileInfoNode, profile);
+  }
+
+  /**
+   * Parse required tags due to specification defined at
+   * {@link https://github.com/bagit-profiles/bagit-profiles}
+   * Note: If one of the tags is missing, a NullPointerException is thrown.
+   *
+   * @param bagitProfileInfoNode Root node of the bagit profile info section.
+   * @param profile Representation of bagit profile.
+   */
+  private static void parseMandatoryTagsOfBagitProfileInfo(final JsonNode bagitProfileInfoNode, final BagitProfile profile) {
+    logger.debug(messages.getString("parsing_mandatory_tags_of_bagit_profile_info_section"));
     
+    
+    // Read required tags
+    // due to specification defined at https://github.com/bagit-profiles/bagit-profiles
     final String profileIdentifier = bagitProfileInfoNode.get("BagIt-Profile-Identifier").asText();
     logger.debug(messages.getString("identifier"), profileIdentifier);
     profile.setBagitProfileIdentifier(profileIdentifier);
@@ -75,14 +93,6 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
     logger.debug(messages.getString("source_organization"), sourceOrg);
     profile.setSourceOrganization(sourceOrg);
     
-    final String contactName = bagitProfileInfoNode.get("Contact-Name").asText();
-    logger.debug(messages.getString("contact_name"), contactName);
-    profile.setContactName(contactName);
-    
-    final String contactEmail = bagitProfileInfoNode.get("Contact-Email").asText();
-    logger.debug(messages.getString("contact_email"), contactEmail);
-    profile.setContactEmail(contactEmail);
-    
     final String extDescript = bagitProfileInfoNode.get("External-Description").asText();
     logger.debug(messages.getString("external_description"), extDescript);
     profile.setExternalDescription(extDescript);
@@ -90,6 +100,38 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
     final String version = bagitProfileInfoNode.get("Version").asText();
     logger.debug(messages.getString("version"), version);
     profile.setVersion(version);
+  }
+
+  /**
+   * Parse optional tags due to specification defined at
+   * {@link https://github.com/bagit-profiles/bagit-profiles}
+   *
+   * @param bagitProfileInfoNode Root node of the bagit profile info section.
+   * @param profile Representation of bagit profile .
+   */
+  private static void parseOptionalTagsOfBagitProfileInfo(final JsonNode bagitProfileInfoNode, final BagitProfile profile) {
+    logger.debug(messages.getString("parsing_optional_tags_of_bagit_profile_info_section"));
+
+    final JsonNode contactNameNode = bagitProfileInfoNode.get("Contact-Name");
+    if (contactNameNode != null) {
+      final String contactName = contactNameNode.asText();
+      logger.debug(messages.getString("contact_name"), contactName);
+      profile.setContactName(contactName);
+    }
+
+    final JsonNode contactEmailNode = bagitProfileInfoNode.get("Contact-Email");
+    if (contactEmailNode != null) {
+      final String contactEmail = contactEmailNode.asText();
+      logger.debug(messages.getString("contact_email"), contactEmail);
+      profile.setContactEmail(contactEmail);
+    }
+
+    final JsonNode contactPhoneNode = bagitProfileInfoNode.get("Contact-Phone");
+    if (contactPhoneNode != null) {
+      final String contactPhone = contactPhoneNode.asText();
+      logger.debug(messages.getString("contact_phone"), contactPhone);
+      profile.setContactPhone(contactPhone);
+    }
   }
   
   @SuppressWarnings("PMD.AvoidInstantiatingObjectsInLoops")
@@ -104,7 +146,16 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
       final Entry<String, JsonNode> node = nodes.next();
       
       final BagInfoRequirement entry = new BagInfoRequirement();
-      entry.setRequired(node.getValue().get("required").asBoolean());
+      // due to specification required is false by default.
+      final JsonNode requiredNode = node.getValue().get("required");
+      if (requiredNode != null) {
+        entry.setRequired(requiredNode.asBoolean());
+      }
+      // due to specification required is false by default.
+      final JsonNode repeatableNode = node.getValue().get("repeatable");
+      if (repeatableNode != null) {
+        entry.setRepeatable(repeatableNode.asBoolean());
+      }
       
       final JsonNode valuesNode = node.getValue().get("values");
       if(valuesNode != null){
@@ -149,24 +200,27 @@ public class BagitProfileDeserializer extends StdDeserializer<BagitProfile> {
   private static List<String> parseRequiredTagmanifestTypes(final JsonNode node){
     final JsonNode tagManifestsRequiredNodes = node.get("Tag-Manifests-Required");
     final List<String> requiredTagmanifestTypes = new ArrayList<>();
-    
-    for(final JsonNode tagManifestsRequiredNode : tagManifestsRequiredNodes){
-      requiredTagmanifestTypes.add(tagManifestsRequiredNode.asText());
+    if (tagManifestsRequiredNodes != null) {
+      for (final JsonNode tagManifestsRequiredNode : tagManifestsRequiredNodes) {
+        requiredTagmanifestTypes.add(tagManifestsRequiredNode.asText());
+      }
     }
     logger.debug(messages.getString("required_tagmanifest_types"), requiredTagmanifestTypes);
-    
+
     return requiredTagmanifestTypes;
   }
   
   private static List<String> parseRequiredTagFiles(final JsonNode node){
     final JsonNode tagFilesRequiredNodes = node.get("Tag-Files-Required");
     final List<String> requiredTagFiles = new ArrayList<>();
-    
-    for(final JsonNode tagFilesRequiredNode : tagFilesRequiredNodes){
-      requiredTagFiles.add(tagFilesRequiredNode.asText());
+
+    if (tagFilesRequiredNodes != null) {
+      for (final JsonNode tagFilesRequiredNode : tagFilesRequiredNodes) {
+        requiredTagFiles.add(tagFilesRequiredNode.asText());
+      }
     }
     logger.debug(messages.getString("tag_files_required"), requiredTagFiles);
-    
+
     return requiredTagFiles;
   }
   

--- a/src/main/java/com/github/jscancella/writer/internal/ManifestWriter.java
+++ b/src/main/java/com/github/jscancella/writer/internal/ManifestWriter.java
@@ -67,8 +67,8 @@ public enum ManifestWriter{;//using enum to enforce singleton
           final String line = entry.getValue() + "  " + RelativePathWriter.formatRelativePathString(relativeTo, entry.getKey());
           logger.debug(messages.getString("writing_line_to_file"), line, manifestPath);
           writer.write(line);
+          }
         }
       }
     }
   }
-}

--- a/src/main/resources/MessageBundle.properties
+++ b/src/main/resources/MessageBundle.properties
@@ -4,10 +4,13 @@
 fetch_allowed=Are fetch files allowed? [{}]
 serialization_allowed=Serialization is: [{}]
 parsing_bagit_profile_info_section=Parsing the BagIt-Profile-Info section
+parsing_mandatory_tags_of_bagit_profile_info_section=Parsing mandatory tags of the BagIt-Profile-Info section
+parsing_optional_tags_of_bagit_profile_info_section=Parsing optional tags of the BagIt-Profile-Info section
 identifier=Identifier is [{}]
 source_organization=Source-Organization is [{}]
 contact_name=Contact-Name is [{}]
 contact_email=Contact-Email is [{}]
+contact_phone=Contact-Phone is [{}]
 external_description=External-Description is [{}]
 version=Version is [{}]
 parsing_bag_info=Parsing the Bag-Info section

--- a/src/test/java/com/github/jscancella/conformance/profile/AbstractBagitProfileTest.java
+++ b/src/test/java/com/github/jscancella/conformance/profile/AbstractBagitProfileTest.java
@@ -1,0 +1,85 @@
+package com.github.jscancella.conformance.profile;
+
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.Map;
+
+import org.junit.jupiter.api.BeforeEach;
+
+import com.fasterxml.jackson.databind.ObjectMapper;
+import com.fasterxml.jackson.databind.module.SimpleModule;
+
+public abstract class AbstractBagitProfileTest {
+  protected ObjectMapper mapper;
+  
+  @BeforeEach
+  public void setup(){
+    mapper = new ObjectMapper();
+    SimpleModule module = new SimpleModule();
+    module.addDeserializer(BagitProfile.class, new BagitProfileDeserializer());
+    mapper.registerModule(module);
+  }
+  
+  protected BagitProfile createExpectedProfile(){
+    BagitProfile expectedProfile = new BagitProfile();
+    
+    expectedProfile.setBagitProfileIdentifier("http://canadiana.org/standards/bagit/tdr_ingest.json");
+    expectedProfile.setContactEmail("tdr@canadiana.com");
+    expectedProfile.setContactName("William Wueppelmann");
+    expectedProfile.setContactPhone("+1 613 907 7040");
+    expectedProfile.setExternalDescription("BagIt profile for ingesting content into the C.O. TDR loading dock.");
+    expectedProfile.setSourceOrganization("Candiana.org");
+    expectedProfile.setVersion("1.2");
+    
+    expectedProfile.setBagInfoRequirements(createBagInfo());
+    expectedProfile.setManifestTypesRequired(Arrays.asList("md5"));
+    expectedProfile.setFetchFileAllowed(false);
+    expectedProfile.setSerialization(Serialization.forbidden);
+    expectedProfile.setAcceptableMIMESerializationTypes(Arrays.asList("application/zip"));
+    expectedProfile.setAcceptableBagitVersions(Arrays.asList("0.96"));
+    expectedProfile.setTagManifestTypesRequired(Arrays.asList("md5"));
+    expectedProfile.setTagFilesRequired(Arrays.asList("DPN/dpnFirstNode.txt", "DPN/dpnRegistry"));
+    
+    return expectedProfile;
+  }
+  
+  protected BagitProfile createMinimalProfile(){
+    BagitProfile expectedProfile = new BagitProfile();
+    
+    expectedProfile.setBagitProfileIdentifier("http://canadiana.org/standards/bagit/tdr_ingest.json");
+    expectedProfile.setExternalDescription("BagIt profile for ingesting content into the C.O. TDR loading dock.");
+    expectedProfile.setSourceOrganization("Candiana.org");
+    expectedProfile.setVersion("1.2");
+    
+    expectedProfile.setBagInfoRequirements(createBagInfo());
+    expectedProfile.setManifestTypesRequired(Arrays.asList("md5"));
+    expectedProfile.setFetchFileAllowed(false);
+    expectedProfile.setSerialization(Serialization.forbidden);
+    expectedProfile.setAcceptableMIMESerializationTypes(Arrays.asList("application/zip"));
+    expectedProfile.setAcceptableBagitVersions(Arrays.asList("0.96"));
+    
+    return expectedProfile;
+  }
+  
+  protected Map<String, BagInfoRequirement> createBagInfo(){
+    Map<String, BagInfoRequirement> info = new HashMap<>();
+    
+    info.put("Source-Organization", new BagInfoRequirement(true, Arrays.asList("Simon Fraser University", "York University"), false));
+    info.put("Organization-Address", new BagInfoRequirement(true, 
+        Arrays.asList("8888 University Drive Burnaby, B.C. V5A 1S6 Canada", "4700 Keele Street Toronto, Ontario M3J 1P3 Canada"), false));
+    info.put("Contact-Name", new BagInfoRequirement(true, Arrays.asList("Mark Jordan", "Nick Ruest"), false));
+    info.put("Contact-Phone", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Contact-Email", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("External-Description", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("External-Identifier", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Bag-Size", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("Bag-Group-Identifier", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Bag-Count", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("Internal-Sender-Identifier", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Internal-Sender-Description", new BagInfoRequirement(false, Arrays.asList(), false));
+    info.put("Bagging-Date", new BagInfoRequirement(true, Arrays.asList(), false));
+    info.put("Payload-Oxum", new BagInfoRequirement(true, Arrays.asList(), false));
+
+    return info;
+  }
+}

--- a/src/test/java/com/github/jscancella/conformance/profile/BagitProfileDeserializerTest.java
+++ b/src/test/java/com/github/jscancella/conformance/profile/BagitProfileDeserializerTest.java
@@ -18,22 +18,7 @@ public class BagitProfileDeserializerTest extends AbstractBagitProfileTest{
     
     BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfile.json"), BagitProfile.class);
     
-    Assertions.assertEquals(expectedProfile, profile);
-    Assertions.assertEquals(expectedProfile.getAcceptableBagitVersions(), profile.getAcceptableBagitVersions());
-    Assertions.assertEquals(expectedProfile.getAcceptableMIMESerializationTypes(), profile.getAcceptableMIMESerializationTypes());
-    Assertions.assertEquals(expectedProfile.getBagInfoRequirements(), profile.getBagInfoRequirements());
-    Assertions.assertEquals(expectedProfile.getBagitProfileIdentifier(), profile.getBagitProfileIdentifier());
-    Assertions.assertEquals(expectedProfile.getContactEmail(), profile.getContactEmail());
-    Assertions.assertEquals(expectedProfile.getContactName(), profile.getContactName());
-    Assertions.assertEquals(expectedProfile.getContactPhone(), profile.getContactPhone());
-    Assertions.assertEquals(expectedProfile.getExternalDescription(), profile.getExternalDescription());
-    Assertions.assertEquals(expectedProfile.getManifestTypesRequired(), profile.getManifestTypesRequired());
-    Assertions.assertEquals(expectedProfile.getSerialization(), profile.getSerialization());
-    Assertions.assertEquals(expectedProfile.getSourceOrganization(), profile.getSourceOrganization());
-    Assertions.assertEquals(expectedProfile.getTagFilesRequired(), profile.getTagFilesRequired());
-    Assertions.assertEquals(expectedProfile.getTagManifestTypesRequired(), profile.getTagManifestTypesRequired());
-    Assertions.assertEquals(expectedProfile.getVersion(), profile.getVersion());
-    Assertions.assertEquals(expectedProfile.hashCode(), profile.hashCode());
+    Assertions.assertTrue(expectedProfile.equals(profile));
   }
   
   @Test
@@ -41,22 +26,7 @@ public class BagitProfileDeserializerTest extends AbstractBagitProfileTest{
     BagitProfile minimalProfile = createMinimalProfile();
     
     BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json"), BagitProfile.class);
-    Assertions.assertEquals(minimalProfile, profile);
-    Assertions.assertEquals(minimalProfile.getAcceptableBagitVersions(), profile.getAcceptableBagitVersions());
-    Assertions.assertEquals(minimalProfile.getAcceptableMIMESerializationTypes(), profile.getAcceptableMIMESerializationTypes());
-    Assertions.assertEquals(minimalProfile.getBagInfoRequirements(), profile.getBagInfoRequirements());
-    Assertions.assertEquals(minimalProfile.getBagitProfileIdentifier(), profile.getBagitProfileIdentifier());
-    Assertions.assertEquals(minimalProfile.getContactEmail(), profile.getContactEmail());
-    Assertions.assertEquals(minimalProfile.getContactName(), profile.getContactName());
-    Assertions.assertEquals(minimalProfile.getContactPhone(), profile.getContactPhone());
-    Assertions.assertEquals(minimalProfile.getExternalDescription(), profile.getExternalDescription());
-    Assertions.assertEquals(minimalProfile.getManifestTypesRequired(), profile.getManifestTypesRequired());
-    Assertions.assertEquals(minimalProfile.getSerialization(), profile.getSerialization());
-    Assertions.assertEquals(minimalProfile.getSourceOrganization(), profile.getSourceOrganization());
-    Assertions.assertEquals(minimalProfile.getTagFilesRequired(), profile.getTagFilesRequired());
-    Assertions.assertEquals(minimalProfile.getTagManifestTypesRequired(), profile.getTagManifestTypesRequired());
-    Assertions.assertEquals(minimalProfile.getVersion(), profile.getVersion());
-    Assertions.assertEquals(minimalProfile.hashCode(), profile.hashCode());
+    Assertions.assertTrue(minimalProfile.equals(profile));
   }
   
   

--- a/src/test/java/com/github/jscancella/conformance/profile/BagitProfileDeserializerTest.java
+++ b/src/test/java/com/github/jscancella/conformance/profile/BagitProfileDeserializerTest.java
@@ -1,0 +1,63 @@
+/*
+ * To change this license header, choose License Headers in Project Properties.
+ * To change this template file, choose Tools | Templates
+ * and open the template in the editor.
+ */
+package com.github.jscancella.conformance.profile;
+
+import java.io.File;
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+
+public class BagitProfileDeserializerTest extends AbstractBagitProfileTest{
+
+  @Test
+  public void testDeserialize() throws Exception{
+    BagitProfile expectedProfile = createExpectedProfile();
+    
+    BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfile.json"), BagitProfile.class);
+    
+    Assertions.assertEquals(expectedProfile, profile);
+    Assertions.assertEquals(expectedProfile.getAcceptableBagitVersions(), profile.getAcceptableBagitVersions());
+    Assertions.assertEquals(expectedProfile.getAcceptableMIMESerializationTypes(), profile.getAcceptableMIMESerializationTypes());
+    Assertions.assertEquals(expectedProfile.getBagInfoRequirements(), profile.getBagInfoRequirements());
+    Assertions.assertEquals(expectedProfile.getBagitProfileIdentifier(), profile.getBagitProfileIdentifier());
+    Assertions.assertEquals(expectedProfile.getContactEmail(), profile.getContactEmail());
+    Assertions.assertEquals(expectedProfile.getContactName(), profile.getContactName());
+    Assertions.assertEquals(expectedProfile.getContactPhone(), profile.getContactPhone());
+    Assertions.assertEquals(expectedProfile.getExternalDescription(), profile.getExternalDescription());
+    Assertions.assertEquals(expectedProfile.getManifestTypesRequired(), profile.getManifestTypesRequired());
+    Assertions.assertEquals(expectedProfile.getSerialization(), profile.getSerialization());
+    Assertions.assertEquals(expectedProfile.getSourceOrganization(), profile.getSourceOrganization());
+    Assertions.assertEquals(expectedProfile.getTagFilesRequired(), profile.getTagFilesRequired());
+    Assertions.assertEquals(expectedProfile.getTagManifestTypesRequired(), profile.getTagManifestTypesRequired());
+    Assertions.assertEquals(expectedProfile.getVersion(), profile.getVersion());
+    Assertions.assertEquals(expectedProfile.hashCode(), profile.hashCode());
+  }
+  
+  @Test
+  public void testDeserializeWithoutOptionalTags() throws Exception{
+    BagitProfile minimalProfile = createMinimalProfile();
+    
+    BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json"), BagitProfile.class);
+    Assertions.assertEquals(minimalProfile, profile);
+    Assertions.assertEquals(minimalProfile.getAcceptableBagitVersions(), profile.getAcceptableBagitVersions());
+    Assertions.assertEquals(minimalProfile.getAcceptableMIMESerializationTypes(), profile.getAcceptableMIMESerializationTypes());
+    Assertions.assertEquals(minimalProfile.getBagInfoRequirements(), profile.getBagInfoRequirements());
+    Assertions.assertEquals(minimalProfile.getBagitProfileIdentifier(), profile.getBagitProfileIdentifier());
+    Assertions.assertEquals(minimalProfile.getContactEmail(), profile.getContactEmail());
+    Assertions.assertEquals(minimalProfile.getContactName(), profile.getContactName());
+    Assertions.assertEquals(minimalProfile.getContactPhone(), profile.getContactPhone());
+    Assertions.assertEquals(minimalProfile.getExternalDescription(), profile.getExternalDescription());
+    Assertions.assertEquals(minimalProfile.getManifestTypesRequired(), profile.getManifestTypesRequired());
+    Assertions.assertEquals(minimalProfile.getSerialization(), profile.getSerialization());
+    Assertions.assertEquals(minimalProfile.getSourceOrganization(), profile.getSourceOrganization());
+    Assertions.assertEquals(minimalProfile.getTagFilesRequired(), profile.getTagFilesRequired());
+    Assertions.assertEquals(minimalProfile.getTagManifestTypesRequired(), profile.getTagManifestTypesRequired());
+    Assertions.assertEquals(minimalProfile.getVersion(), profile.getVersion());
+    Assertions.assertEquals(minimalProfile.hashCode(), profile.hashCode());
+  }
+  
+  
+}

--- a/src/test/java/com/github/jscancella/conformance/profile/BagitProfileTest.java
+++ b/src/test/java/com/github/jscancella/conformance/profile/BagitProfileTest.java
@@ -1,0 +1,115 @@
+package com.github.jscancella.conformance.profile;
+
+import java.io.File;
+import java.util.Arrays;
+import java.util.HashMap;
+
+import org.junit.jupiter.api.Assertions;
+import org.junit.jupiter.api.Test;
+
+public class BagitProfileTest extends AbstractBagitProfileTest{
+  
+  @Test
+  public void testToString() throws Exception{
+    String expectedOutput = "BagitProfile [bagitProfileIdentifier=http://canadiana.org/standards/bagit/tdr_ingest.json, "
+        + "sourceOrganization=Candiana.org, "
+        + "externalDescription=BagIt profile for ingesting content into the C.O. TDR loading dock., "
+        + "contactName=William Wueppelmann, "
+        + "contactEmail=tdr@canadiana.com, "
+        + "contactPhone=+1 613 907 7040, "
+        + "version=1.2, "
+        + "bagInfoRequirements={"
+        + "Payload-Oxum=[required=true, acceptableValues=[], repeatable=false], "
+        + "Bag-Size=[required=true, acceptableValues=[], repeatable=false], "
+        + "Bagging-Date=[required=true, acceptableValues=[], repeatable=false], "
+        + "Source-Organization=[required=true, acceptableValues=[Simon Fraser University, York University], repeatable=false], "
+        + "Bag-Count=[required=true, acceptableValues=[], repeatable=false], "
+        + "Organization-Address=[required=true, acceptableValues=[8888 University Drive Burnaby, B.C. V5A 1S6 Canada, 4700 Keele Street Toronto, Ontario M3J 1P3 Canada], repeatable=false], "
+        + "Bag-Group-Identifier=[required=false, acceptableValues=[], repeatable=false], "
+        + "External-Identifier=[required=false, acceptableValues=[], repeatable=false], "
+        + "Internal-Sender-Identifier=[required=false, acceptableValues=[], repeatable=false], "
+        + "Contact-Email=[required=true, acceptableValues=[], repeatable=false], "
+        + "Contact-Phone=[required=false, acceptableValues=[], repeatable=false], "
+        + "Internal-Sender-Description=[required=false, acceptableValues=[], repeatable=false], "
+        + "External-Description=[required=true, acceptableValues=[], repeatable=false], "
+        + "Contact-Name=[required=true, acceptableValues=[Mark Jordan, Nick Ruest], repeatable=false]}, "
+        + "manifestTypesRequired=[md5], "
+        + "fetchFileAllowed=false, "
+        + "serialization=forbidden, "
+        + "acceptableMIMESerializationTypes=[application/zip], "
+        + "acceptableBagitVersions=[0.96], "
+        + "tagManifestTypesRequired=[md5], "
+        + "tagFilesRequired=[DPN/dpnFirstNode.txt, DPN/dpnRegistry]]";
+    
+    BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfile.json"), BagitProfile.class);
+    System.err.println(profile.toString());
+    Assertions.assertEquals(expectedOutput, profile.toString());
+  }
+  
+  @Test
+  public void testEquals(){
+    BagitProfile profile = createExpectedProfile();
+    
+    Assertions.assertFalse(profile.equals(null));
+    
+    BagitProfile differentBagitProfileIdentifier = createExpectedProfile();
+    differentBagitProfileIdentifier.setBagitProfileIdentifier("foo");
+    Assertions.assertFalse(profile.equals(differentBagitProfileIdentifier));
+    
+    BagitProfile differentSourceOrganization = createExpectedProfile();
+    differentSourceOrganization.setSourceOrganization("foo");
+    Assertions.assertFalse(profile.equals(differentSourceOrganization));
+    
+    BagitProfile differentExternalDescription = createExpectedProfile();
+    differentExternalDescription.setExternalDescription("foo");
+    Assertions.assertFalse(profile.equals(differentExternalDescription));
+    
+    BagitProfile differentContactName = createExpectedProfile();
+    differentContactName.setContactName("foo");
+    Assertions.assertFalse(profile.equals(differentContactName));
+    
+    BagitProfile differentContactEmail = createExpectedProfile();
+    differentContactEmail.setContactEmail("foo");
+    Assertions.assertFalse(profile.equals(differentContactEmail));
+    
+    BagitProfile differentContactPhone = createExpectedProfile();
+    differentContactPhone.setContactPhone("foo");
+    Assertions.assertFalse(profile.equals(differentContactPhone));
+    
+    BagitProfile differentVersion = createExpectedProfile();
+    differentVersion.setVersion("foo");
+    Assertions.assertFalse(profile.equals(differentVersion));
+    
+    BagitProfile differentBagInfoRequirements = createExpectedProfile();
+    differentBagInfoRequirements.setBagInfoRequirements(new HashMap<>());
+    Assertions.assertFalse(profile.equals(differentBagInfoRequirements));
+    
+    BagitProfile differentManifestTypesRequired = createExpectedProfile();
+    differentManifestTypesRequired.setManifestTypesRequired(Arrays.asList("foo"));
+    Assertions.assertFalse(profile.equals(differentManifestTypesRequired));
+    
+    BagitProfile differentFetchFileAllowed = createExpectedProfile();
+    differentFetchFileAllowed.setFetchFileAllowed(true);
+    Assertions.assertFalse(profile.equals(differentFetchFileAllowed));
+    
+    BagitProfile differentSerialization = createExpectedProfile();
+    differentSerialization.setSerialization(Serialization.required);
+    Assertions.assertFalse(profile.equals(differentSerialization));
+    
+    BagitProfile differentAcceptableMIMESerializationTypes = createExpectedProfile();
+    differentAcceptableMIMESerializationTypes.setAcceptableMIMESerializationTypes(Arrays.asList("foo"));
+    Assertions.assertFalse(profile.equals(differentAcceptableMIMESerializationTypes));
+    
+    BagitProfile differentAcceptableBagitVersions = createExpectedProfile();
+    differentAcceptableBagitVersions.setAcceptableBagitVersions(Arrays.asList("foo"));
+    Assertions.assertFalse(profile.equals(differentAcceptableBagitVersions));
+    
+    BagitProfile differentTagManifestTypesRequired = createExpectedProfile();
+    differentTagManifestTypesRequired.setTagManifestTypesRequired(Arrays.asList("foo"));
+    Assertions.assertFalse(profile.equals(differentTagManifestTypesRequired));
+    
+    BagitProfile differentTagFilesRequired = createExpectedProfile();
+    differentTagFilesRequired.setTagFilesRequired(Arrays.asList("foo"));
+    Assertions.assertFalse(profile.equals(differentTagFilesRequired));
+  }
+}

--- a/src/test/java/com/github/jscancella/conformance/profile/BagitProfileTest.java
+++ b/src/test/java/com/github/jscancella/conformance/profile/BagitProfileTest.java
@@ -1,115 +1,70 @@
 package com.github.jscancella.conformance.profile;
 
-import java.io.File;
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Type;
+import java.lang.reflect.Method;
+import java.util.ArrayList;
 import java.util.Arrays;
-import java.util.HashMap;
+import java.util.List;
 
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
-public class BagitProfileTest extends AbstractBagitProfileTest{
-  
+public class BagitProfileTest extends AbstractBagitProfileTest {
+
   @Test
-  public void testToString() throws Exception{
-    String expectedOutput = "BagitProfile [bagitProfileIdentifier=http://canadiana.org/standards/bagit/tdr_ingest.json, "
-        + "sourceOrganization=Candiana.org, "
-        + "externalDescription=BagIt profile for ingesting content into the C.O. TDR loading dock., "
-        + "contactName=William Wueppelmann, "
-        + "contactEmail=tdr@canadiana.com, "
-        + "contactPhone=+1 613 907 7040, "
-        + "version=1.2, "
-        + "bagInfoRequirements={"
-        + "Payload-Oxum=[required=true, acceptableValues=[], repeatable=false], "
-        + "Bag-Size=[required=true, acceptableValues=[], repeatable=false], "
-        + "Bagging-Date=[required=true, acceptableValues=[], repeatable=false], "
-        + "Source-Organization=[required=true, acceptableValues=[Simon Fraser University, York University], repeatable=false], "
-        + "Bag-Count=[required=true, acceptableValues=[], repeatable=false], "
-        + "Organization-Address=[required=true, acceptableValues=[8888 University Drive Burnaby, B.C. V5A 1S6 Canada, 4700 Keele Street Toronto, Ontario M3J 1P3 Canada], repeatable=false], "
-        + "Bag-Group-Identifier=[required=false, acceptableValues=[], repeatable=false], "
-        + "External-Identifier=[required=false, acceptableValues=[], repeatable=false], "
-        + "Internal-Sender-Identifier=[required=false, acceptableValues=[], repeatable=false], "
-        + "Contact-Email=[required=true, acceptableValues=[], repeatable=false], "
-        + "Contact-Phone=[required=false, acceptableValues=[], repeatable=false], "
-        + "Internal-Sender-Description=[required=false, acceptableValues=[], repeatable=false], "
-        + "External-Description=[required=true, acceptableValues=[], repeatable=false], "
-        + "Contact-Name=[required=true, acceptableValues=[Mark Jordan, Nick Ruest], repeatable=false]}, "
-        + "manifestTypesRequired=[md5], "
-        + "fetchFileAllowed=false, "
-        + "serialization=forbidden, "
-        + "acceptableMIMESerializationTypes=[application/zip], "
-        + "acceptableBagitVersions=[0.96], "
-        + "tagManifestTypesRequired=[md5], "
-        + "tagFilesRequired=[DPN/dpnFirstNode.txt, DPN/dpnRegistry]]";
-    
-    BagitProfile profile = mapper.readValue(new File("src/test/resources/bagitProfiles/exampleProfile.json"), BagitProfile.class);
-    System.err.println(profile.toString());
-    Assertions.assertEquals(expectedOutput, profile.toString());
-  }
-  
-  @Test
-  public void testEquals(){
-    BagitProfile profile = createExpectedProfile();
-    
-    Assertions.assertFalse(profile.equals(null));
-    
-    BagitProfile differentBagitProfileIdentifier = createExpectedProfile();
-    differentBagitProfileIdentifier.setBagitProfileIdentifier("foo");
-    Assertions.assertFalse(profile.equals(differentBagitProfileIdentifier));
-    
-    BagitProfile differentSourceOrganization = createExpectedProfile();
-    differentSourceOrganization.setSourceOrganization("foo");
-    Assertions.assertFalse(profile.equals(differentSourceOrganization));
-    
-    BagitProfile differentExternalDescription = createExpectedProfile();
-    differentExternalDescription.setExternalDescription("foo");
-    Assertions.assertFalse(profile.equals(differentExternalDescription));
-    
-    BagitProfile differentContactName = createExpectedProfile();
-    differentContactName.setContactName("foo");
-    Assertions.assertFalse(profile.equals(differentContactName));
-    
-    BagitProfile differentContactEmail = createExpectedProfile();
-    differentContactEmail.setContactEmail("foo");
-    Assertions.assertFalse(profile.equals(differentContactEmail));
-    
-    BagitProfile differentContactPhone = createExpectedProfile();
-    differentContactPhone.setContactPhone("foo");
-    Assertions.assertFalse(profile.equals(differentContactPhone));
-    
-    BagitProfile differentVersion = createExpectedProfile();
-    differentVersion.setVersion("foo");
-    Assertions.assertFalse(profile.equals(differentVersion));
-    
-    BagitProfile differentBagInfoRequirements = createExpectedProfile();
-    differentBagInfoRequirements.setBagInfoRequirements(new HashMap<>());
-    Assertions.assertFalse(profile.equals(differentBagInfoRequirements));
-    
-    BagitProfile differentManifestTypesRequired = createExpectedProfile();
-    differentManifestTypesRequired.setManifestTypesRequired(Arrays.asList("foo"));
-    Assertions.assertFalse(profile.equals(differentManifestTypesRequired));
-    
-    BagitProfile differentFetchFileAllowed = createExpectedProfile();
-    differentFetchFileAllowed.setFetchFileAllowed(true);
-    Assertions.assertFalse(profile.equals(differentFetchFileAllowed));
-    
-    BagitProfile differentSerialization = createExpectedProfile();
-    differentSerialization.setSerialization(Serialization.required);
-    Assertions.assertFalse(profile.equals(differentSerialization));
-    
-    BagitProfile differentAcceptableMIMESerializationTypes = createExpectedProfile();
-    differentAcceptableMIMESerializationTypes.setAcceptableMIMESerializationTypes(Arrays.asList("foo"));
-    Assertions.assertFalse(profile.equals(differentAcceptableMIMESerializationTypes));
-    
-    BagitProfile differentAcceptableBagitVersions = createExpectedProfile();
-    differentAcceptableBagitVersions.setAcceptableBagitVersions(Arrays.asList("foo"));
-    Assertions.assertFalse(profile.equals(differentAcceptableBagitVersions));
-    
-    BagitProfile differentTagManifestTypesRequired = createExpectedProfile();
-    differentTagManifestTypesRequired.setTagManifestTypesRequired(Arrays.asList("foo"));
-    Assertions.assertFalse(profile.equals(differentTagManifestTypesRequired));
-    
-    BagitProfile differentTagFilesRequired = createExpectedProfile();
-    differentTagFilesRequired.setTagFilesRequired(Arrays.asList("foo"));
-    Assertions.assertFalse(profile.equals(differentTagFilesRequired));
+  public void testEquals() {
+    // define parameters
+    String asString = "foo";
+    List<String> asList = Arrays.asList(asString);
+    boolean asBoolean = true;
+    Serialization asSerialization = Serialization.required;
+
+    try {
+      BagitProfile profile = createExpectedProfile();
+
+      Assertions.assertFalse(profile.equals(null));
+
+      BagitProfile identicalProfile = createExpectedProfile();
+      Assertions.assertTrue(profile.equals(identicalProfile));
+
+      Class testModelClass = BagitProfile.class;
+      Method[] methods = testModelClass.getDeclaredMethods();
+      for (Method method
+              : methods) {
+        BagitProfile otherProfile = createExpectedProfile();
+
+        if (method.getName().startsWith("set")) {
+          Type[] pType = method.getGenericParameterTypes();
+          if (pType.length == 0) {
+            continue;
+          }
+          /**
+           * Create array for parameters
+           */
+          Object[] params = new Object[pType.length];
+
+          for (int i = 0; i < pType.length; i++) {
+            if (pType[i].equals(String.class)) {
+              params[i] = asString;
+
+            } else if (pType[i].getTypeName().equals("java.util.List<java.lang.String>")) {
+              params[i] = asList;
+            } else if (pType[i].equals(boolean.class)) {
+              params[i] = asBoolean;
+            } else if (pType[i].equals(Serialization.class)) {
+              params[i] = asSerialization;
+            }
+
+          }
+          method.setAccessible(true);
+          method.invoke(otherProfile, params);
+
+          Assertions.assertFalse(otherProfile.equals(profile));
+        }
+      }
+    } catch (IllegalAccessException | IllegalArgumentException | InvocationTargetException e) {
+      Assertions.assertFalse(true);
+    }
   }
 }

--- a/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
+++ b/src/test/resources/bagitProfiles/exampleProfileOnlyRequiredFields.json
@@ -2,9 +2,6 @@
   "BagIt-Profile-Info": {
     "BagIt-Profile-Identifier": "http://canadiana.org/standards/bagit/tdr_ingest.json",
     "Source-Organization": "Candiana.org",
-    "Contact-Name": "William Wueppelmann",
-    "Contact-Email": "tdr@canadiana.com",
-    "Contact-Phone": "+1 613 907 7040",
     "External-Description": "BagIt profile for ingesting content into the C.O. TDR loading dock.",
     "Version": "1.2"
   },
@@ -34,7 +31,6 @@
       "repeatable": false
     },
     "Contact-Phone": {
-      "required": false,
       "repeatable": false
     },
     "Contact-Email": {
@@ -46,7 +42,6 @@
       "repeatable": false
     },
     "External-Identifier": {
-      "required": false,
       "repeatable": false
     },
     "Bag-Size": {
@@ -54,7 +49,6 @@
       "repeatable": false
     },
     "Bag-Group-Identifier": {
-      "required": false,
       "repeatable": false
     },
     "Bag-Count": {
@@ -62,11 +56,9 @@
       "repeatable": false
     },
     "Internal-Sender-Identifier": {
-      "required": false,
       "repeatable": false
     },
     "Internal-Sender-Description": {
-      "required": false,
       "repeatable": false
     },
     "Bagging-Date": {
@@ -85,13 +77,6 @@
   "Serialization": "forbidden",
   "Accept-Serialization": [
     "application/zip"
-  ],
-  "Tag-Manifests-Required": [
-    "md5"
-  ],
-  "Tag-Files-Required": [
-    "DPN/dpnFirstNode.txt",
-    "DPN/dpnRegistry"
   ],
   "Accept-BagIt-Version": [
     "0.96"


### PR DESCRIPTION
…/bagit-profiles/bagit-profiles)

Bag-Info:
The parameters "required" is 'false' and "repeatable" is 'true' by default.
Changed implementation accordingly.
Inclusion of "Contact-Name," "Contact-Phone" and "Contact-Email," as defined in the BagIt spec, is not required but is encouraged.
-> Add "Contact-Phone"
-> "Contact-Name" and "Contact-Email" are now optional
Make field "Tag-Manifests-Required" optional 
Make field "Tag-Files-Required" optional 
Add test for minimal profile
Adapt other tests.

### Please ensure you have completed the following before submitting:
- Ran `gradle clean check` to ensure existing functionality wasn't broken and code meets quality standards.

If the build fails, please fix it because the pull request will not be merged until it builds without any errors.