### PR TITLE
Javadoc fixes

### DIFF
--- a/src/main/java/com/github/jscancella/conformance/internal/LargeBagChecker.java
+++ b/src/main/java/com/github/jscancella/conformance/internal/LargeBagChecker.java
@@ -32,7 +32,7 @@ public enum LargeBagChecker { ; //using enum to enforce singleton
   private static final long LARGE_PAYLOAD_SIZE = ONE_TERABYTE; 
   
   /**
-   * Check if a bag is "large", which is: </br>
+   * Check if a bag is "large", which is: <br>
    * * A large number of files
    * * A large total size of the bag
    * * A large number of manifests

--- a/src/main/java/com/github/jscancella/verify/internal/BagitTextFileVerifier.java
+++ b/src/main/java/com/github/jscancella/verify/internal/BagitTextFileVerifier.java
@@ -20,8 +20,8 @@ public enum BagitTextFileVerifier {; //using to enforce singleton
   
   /**
    * Starting with version 1.0, the bagit.txt file must be EXACTLY 2 lines.
-   * @param bag
-   * @throws IOException
+   * @param bag the bag containing the bagit.txt file to verify
+   * @throws IOException if the bagit.txt file cannot be read
    */
   public static void checkBagitTextFile(final Bag bag) throws IOException {
     if(Version.VERSION_1_0().isSameOrNewer(bag.getVersion())){


### PR DESCRIPTION
Addresses issue #33:  Fix javadoc errors thrown during the javadoc task of the check phase.