### PR TITLE
refs #52 - do not use a global hasher

### DIFF
--- a/src/main/java/com/github/jscancella/hash/DefaultHasher.java
+++ b/src/main/java/com/github/jscancella/hash/DefaultHasher.java
@@ -1,0 +1,83 @@
+package com.github.jscancella.hash;
+
+import java.io.BufferedInputStream;
+import java.io.IOException;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardOpenOption;
+import java.security.MessageDigest;
+import java.security.NoSuchAlgorithmException;
+import java.util.Formatter;
+
+/**
+ * Default {@link Hasher} implementation that computes digests using Java's {@link MessageDigest}.
+ */
+class DefaultHasher implements Hasher {
+
+  private static final int _64_KB = 1024 * 64;
+  private static final int CHUNK_SIZE = _64_KB;
+  private transient MessageDigest messageDigestInstance;
+  private final transient String MESSAGE_DIGEST_NAME;
+  private final transient String BAGIT_ALGORITHM_NAME;
+
+  /* default */ DefaultHasher(final String digestName, final String bagitAlgorithmName) {
+      MESSAGE_DIGEST_NAME = digestName;
+      BAGIT_ALGORITHM_NAME = bagitAlgorithmName;
+  }
+
+  @Override
+  public String hash(final Path path) throws IOException {
+      reset();
+      updateMessageDigest(path, messageDigestInstance);
+      return formatMessageDigest(messageDigestInstance);
+  }
+
+  private static void updateMessageDigest(final Path path, final MessageDigest messageDigest) throws IOException{
+      try(InputStream inputStream = new BufferedInputStream(Files.newInputStream(path, StandardOpenOption.READ))){
+          final byte[] buffer = new byte[CHUNK_SIZE];
+          int read = inputStream.read(buffer);
+
+          while(read != -1){
+              messageDigest.update(buffer, 0, read);
+              read = inputStream.read(buffer);
+          }
+      }
+  }
+
+  private static String formatMessageDigest(final MessageDigest messageDigest){
+      try(Formatter formatter = new Formatter()){
+          for (final byte b : messageDigest.digest()) {
+              formatter.format("%02x", b);
+          }
+
+          return formatter.toString();
+      }
+  }
+
+  @Override
+  public String getHash(){
+      return formatMessageDigest(messageDigestInstance);
+  }
+
+  @Override
+  public void update(final byte[] bytes){
+      messageDigestInstance.update(bytes);
+  }
+
+  @Override
+  public void reset(){
+      messageDigestInstance.reset();
+  }
+
+  @Override
+  public String getBagitAlgorithmName(){
+      return BAGIT_ALGORITHM_NAME;
+  }
+
+  @Override
+  public void initialize() throws NoSuchAlgorithmException {
+      messageDigestInstance = MessageDigest.getInstance(MESSAGE_DIGEST_NAME);
+  }
+
+}

--- a/src/main/java/com/github/jscancella/hash/Hasher.java
+++ b/src/main/java/com/github/jscancella/hash/Hasher.java
@@ -14,7 +14,7 @@ public interface Hasher {
    * 
    * @param path the {@link Path} (file) to hash
    * 
-   * @return the hash as a hex formated string
+   * @return the hash as a hex formatted string
    * 
    * @throws IOException if there is a problem reading the file
    */

--- a/src/main/java/com/github/jscancella/hash/HasherFactory.java
+++ b/src/main/java/com/github/jscancella/hash/HasherFactory.java
@@ -1,0 +1,20 @@
+package com.github.jscancella.hash;
+
+/**
+ * Interface for creating {@link Hasher} instances
+ */
+public interface HasherFactory {
+
+  /**
+   * Create a new {@link Hasher} instance
+   *
+   * @return a new hasher
+   */
+  Hasher createHasher();
+
+  /**
+   * @return the bagit formatted version of the algorithm name. For example if the hasher implements MD5, it would return md5 as the name.
+   */
+  String getBagitAlgorithmName();
+
+}

--- a/src/main/java/com/github/jscancella/hash/StandardHasher.java
+++ b/src/main/java/com/github/jscancella/hash/StandardHasher.java
@@ -1,20 +1,10 @@
 package com.github.jscancella.hash;
 
-import java.io.BufferedInputStream;
-import java.io.IOException;
-import java.io.InputStream;
-import java.nio.file.Files;
-import java.nio.file.Path;
-import java.nio.file.StandardOpenOption;
-import java.security.MessageDigest;
-import java.security.NoSuchAlgorithmException;
-import java.util.Formatter;
-
 /**
  * Constant definitions for the standard {@link Hasher}. Pretty much every computer will be able to implement these.
  */
 @SuppressWarnings({"PMD.AvoidMessageDigestField"})
-public enum StandardHasher implements Hasher {
+public enum StandardHasher implements HasherFactory {
   /**
    * The md5 checksum algorithm
    */
@@ -39,70 +29,23 @@ public enum StandardHasher implements Hasher {
    * The sha-2 checksum algorithm using 512 bits
    */
   SHA512("SHA-512", "sha512");
-  
-  private static final int _64_KB = 1024 * 64;
-  private static final int CHUNK_SIZE = _64_KB;
-  private MessageDigest messageDigestInstance;
+
   private final String MESSAGE_DIGEST_NAME;
   private final String BAGIT_ALGORITHM_NAME;
-  
+
   StandardHasher(final String digestName, final String bagitAlgorithmName) {
-    MESSAGE_DIGEST_NAME = digestName;
-    BAGIT_ALGORITHM_NAME = bagitAlgorithmName;
-  }
-  
-  @Override
-  public String hash(final Path path) throws IOException{
-    reset();
-    updateMessageDigest(path, messageDigestInstance);
-    return formatMessageDigest(messageDigestInstance);
-  }
-  
-  private static void updateMessageDigest(final Path path, final MessageDigest messageDigest) throws IOException{
-    try(InputStream inputStream = new BufferedInputStream(Files.newInputStream(path, StandardOpenOption.READ))){
-      final byte[] buffer = new byte[CHUNK_SIZE];
-      int read = inputStream.read(buffer);
-
-      while(read != -1){
-        messageDigest.update(buffer, 0, read);
-        read = inputStream.read(buffer);
-      }
-    }
-  }
-  
-  private static String formatMessageDigest(final MessageDigest messageDigest){
-    try(Formatter formatter = new Formatter()){
-      for (final byte b : messageDigest.digest()) {
-        formatter.format("%02x", b);
-      }
-      
-      return formatter.toString();
-    }
-  }
-  
-  @Override
-  public String getHash(){
-    return formatMessageDigest(messageDigestInstance);
+    this.MESSAGE_DIGEST_NAME = digestName;
+    this.BAGIT_ALGORITHM_NAME = bagitAlgorithmName;
   }
 
   @Override
-  public void update(final byte[] bytes){
-    messageDigestInstance.update(bytes);
-  }
-
-  @Override
-  public void reset(){
-    messageDigestInstance.reset();
+  public Hasher createHasher() {
+    return new DefaultHasher(MESSAGE_DIGEST_NAME, BAGIT_ALGORITHM_NAME);
   }
 
   @Override
   public String getBagitAlgorithmName(){
     return BAGIT_ALGORITHM_NAME;
-  }
-  
-  @Override
-  public void initialize() throws NoSuchAlgorithmException{
-    messageDigestInstance = MessageDigest.getInstance(MESSAGE_DIGEST_NAME);
   }
 
 }

--- a/src/main/java/com/github/jscancella/reader/internal/FetchReader.java
+++ b/src/main/java/com/github/jscancella/reader/internal/FetchReader.java
@@ -44,14 +44,14 @@ public enum FetchReader {;//using enum to enforce singleton
     
     try(BufferedReader reader = Files.newBufferedReader(fetchFile, encoding)){
       String line = reader.readLine();
-      String[] parts = null;
-      long length = 0;
-      URI url = null;
+      String[] parts;
+      long length;
+      URI url;
       while(line != null){
         if(line.matches(FETCH_LINE_REGEX) && !line.matches("\\s*")){
           parts = line.split("\\s+", 3);
           final Path path = TagFileReader.createFileFromManifest(bagRootDir, parts[2]);
-          length = parts[1].equals("-") ? -1 : Long.decode(parts[1]);
+          length = "-".equals(parts[1]) ? -1 : Long.decode(parts[1]);
           url = URI.create(parts[0]);
           
           logger.debug(messages.getString("read_fetch_file_line"), url, length, parts[2], fetchFile);

--- a/src/test/java/com/github/jscancella/domain/BagTest.java
+++ b/src/test/java/com/github/jscancella/domain/BagTest.java
@@ -1,11 +1,19 @@
 package com.github.jscancella.domain;
 
+import java.io.IOException;
 import java.net.URI;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
+import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.concurrent.Executor;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Phaser;
 
+import com.github.jscancella.hash.Hasher;
 import org.junit.jupiter.api.Assertions;
 import org.junit.jupiter.api.Test;
 
@@ -67,22 +75,26 @@ public class BagTest extends TempFolderTest{
     Path expectedFetchFile = rootDir.resolve("fetch.txt");
     
     Assertions.assertTrue(Files.exists(expectedBagitFile));
-    String bagitFileHash = StandardHasher.MD5.hash(expectedBagitFile);
+
+    Hasher hasher = StandardHasher.MD5.createHasher();
+    hasher.initialize();
+
+    String bagitFileHash = hasher.hash(expectedBagitFile);
     Assertions.assertEquals(
         Arrays.asList("BagIt-Version: 1.0","Tag-File-Character-Encoding: UTF-8"), Files.readAllLines(expectedBagitFile));
     
     Assertions.assertTrue(Files.exists(expectedMetadataFile));
-    String metadataFileHash = StandardHasher.MD5.hash(expectedMetadataFile);
+    String metadataFileHash = hasher.hash(expectedMetadataFile);
     Assertions.assertEquals(
         Arrays.asList("foo: bar"), Files.readAllLines(expectedMetadataFile));
     
     Assertions.assertTrue(Files.exists(expectedManifestFile));
-    String manifestFileHash = StandardHasher.MD5.hash(expectedManifestFile);
+    String manifestFileHash = hasher.hash(expectedManifestFile);
     Assertions.assertEquals(
         Arrays.asList("b1946ac92492d2347c6235b4d2611184  data/foo.txt"), Files.readAllLines(expectedManifestFile));
     
     Assertions.assertTrue(Files.exists(expectedFetchFile));
-    String fetchFileHash = StandardHasher.MD5.hash(expectedFetchFile);
+    String fetchFileHash = hasher.hash(expectedFetchFile);
     
     Assertions.assertTrue(Files.exists(expectedTagmanifestFile));
     Assertions.assertEquals(
@@ -97,5 +109,46 @@ public class BagTest extends TempFolderTest{
     Assertions.assertArrayEquals(Files.readAllBytes(tagFile), Files.readAllBytes(expectedTagFile));
     
     
+  }
+
+  @Test
+  public void concurrentTest() throws IOException {
+    List<Path> bags = new ArrayList<>();
+    bags.add(Files.createDirectories(folder.resolve("bag-1")));
+    bags.add(Files.createDirectories(folder.resolve("bag-2")));
+
+    byte[] content = new byte[10_000];
+    Arrays.fill(content, (byte) 'a');
+    Path file = Files.write(folder.resolve("test.txt"), content);
+
+    Executor executor = Executors.newFixedThreadPool(bags.size());
+    Phaser phaser = new Phaser(bags.size() + 1);
+
+    bags.forEach(bagDir -> {
+      executor.execute(() -> {
+        phaser.arriveAndAwaitAdvance();
+        try {
+          new BagBuilder()
+                  .addAlgorithm("sha256")
+                  .bagLocation(bagDir)
+                  .addPayloadFile(file)
+                  .write();
+          phaser.arrive();
+        } catch (Exception e) {
+          e.printStackTrace();
+        }
+      });
+    });
+
+    phaser.arriveAndAwaitAdvance();
+    phaser.arriveAndAwaitAdvance();
+
+    bags.forEach(bagDir -> {
+      try {
+        Bag.read(bagDir).justValidate();
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    });
   }
 }

--- a/src/test/java/com/github/jscancella/hash/BagitChecksumNameMappingTest.java
+++ b/src/test/java/com/github/jscancella/hash/BagitChecksumNameMappingTest.java
@@ -11,30 +11,40 @@ public class BagitChecksumNameMappingTest {
 
   @Test
   void addShouldReturnFalseGivenNotValidAlgorithm() {
-    boolean result = BagitChecksumNameMapping.add("not-valid", new Hasher() {
+    boolean result = BagitChecksumNameMapping.add("not-valid", new HasherFactory() {
       @Override
-      public String hash(Path path) throws IOException {
-        return "not-valid";
-      }
+      public Hasher createHasher() {
+        return new Hasher() {
+          @Override
+          public String hash(Path path) throws IOException {
+            return "not-valid";
+          }
 
-      @Override
-      public void initialize() throws NoSuchAlgorithmException {
-        throw new NoSuchAlgorithmException("not-valid");
-      }
+          @Override
+          public void initialize() throws NoSuchAlgorithmException {
+            throw new NoSuchAlgorithmException("not-valid");
+          }
 
-      @Override
-      public void update(byte[] bytes) {
+          @Override
+          public void update(byte[] bytes) {
 
-      }
+          }
 
-      @Override
-      public String getHash() {
-        return "not-valid";
-      }
+          @Override
+          public String getHash() {
+            return "not-valid";
+          }
 
-      @Override
-      public void reset() {
+          @Override
+          public void reset() {
 
+          }
+
+          @Override
+          public String getBagitAlgorithmName() {
+            return "not-valid";
+          }
+        };
       }
 
       @Override

--- a/src/test/java/com/github/jscancella/verify/SHA3Hasher.java
+++ b/src/test/java/com/github/jscancella/verify/SHA3Hasher.java
@@ -11,67 +11,80 @@ import java.security.NoSuchAlgorithmException;
 import java.util.Formatter;
 
 import com.github.jscancella.hash.Hasher;
+import com.github.jscancella.hash.HasherFactory;
 
-public enum SHA3Hasher implements Hasher {
+public enum SHA3Hasher implements HasherFactory {
   INSTANCE;// using enum to enforce singleton
   
   private static final int _64_KB = 1024 * 64;
   private static final int CHUNK_SIZE = _64_KB;
   private static final String MESSAGE_DIGEST_NAME = "SHA3-256";
-  private MessageDigest messageDigestInstance;
 
   @Override
-  public String hash(Path path) throws IOException{
-    reset();
-    updateMessageDigest(path, messageDigestInstance);
-    return formatMessageDigest(messageDigestInstance);
+  public Hasher createHasher() {
+    return new InnerHasher();
   }
 
   @Override
-  public void update(byte[] bytes){
-    messageDigestInstance.update(bytes, 0, bytes.length);
-  }
-
-  @Override
-  public String getHash(){
-    return formatMessageDigest(messageDigestInstance);
-  }
-
-  @Override
-  public void reset(){
-    messageDigestInstance.reset();
-  }
-
-  @Override
-  public String getBagitAlgorithmName(){
+  public String getBagitAlgorithmName() {
     return "sha3256";
   }
-  
-  private static void updateMessageDigest(final Path path, final MessageDigest messageDigest) throws IOException{
-    try(final InputStream is = new BufferedInputStream(Files.newInputStream(path, StandardOpenOption.READ))){
-      final byte[] buffer = new byte[CHUNK_SIZE];
-      int read = is.read(buffer);
 
-      while(read != -1){
-        messageDigest.update(buffer, 0, read);
-        read = is.read(buffer);
+  static class InnerHasher implements Hasher {
+    private MessageDigest messageDigestInstance;
+
+    @Override
+    public String hash(Path path) throws IOException {
+      reset();
+      updateMessageDigest(path, messageDigestInstance);
+      return formatMessageDigest(messageDigestInstance);
+    }
+
+    @Override
+    public void update(byte[] bytes) {
+      messageDigestInstance.update(bytes, 0, bytes.length);
+    }
+
+    @Override
+    public String getHash() {
+      return formatMessageDigest(messageDigestInstance);
+    }
+
+    @Override
+    public void reset() {
+      messageDigestInstance.reset();
+    }
+
+    @Override
+    public String getBagitAlgorithmName() {
+      return "sha3256";
+    }
+
+    private static void updateMessageDigest(final Path path, final MessageDigest messageDigest) throws IOException {
+      try (final InputStream is = new BufferedInputStream(Files.newInputStream(path, StandardOpenOption.READ))) {
+        final byte[] buffer = new byte[CHUNK_SIZE];
+        int read = is.read(buffer);
+
+        while (read != -1) {
+          messageDigest.update(buffer, 0, read);
+          read = is.read(buffer);
+        }
       }
     }
-  }
-  
-  private static String formatMessageDigest(final MessageDigest messageDigest){
-    try(final Formatter formatter = new Formatter()){
-      for (final byte b : messageDigest.digest()) {
-        formatter.format("%02x", b);
+
+    private static String formatMessageDigest(final MessageDigest messageDigest) {
+      try (final Formatter formatter = new Formatter()) {
+        for (final byte b : messageDigest.digest()) {
+          formatter.format("%02x", b);
+        }
+
+        return formatter.toString();
       }
-      
-      return formatter.toString();
+    }
+
+    @Override
+    public void initialize() throws NoSuchAlgorithmException {
+      messageDigestInstance = MessageDigest.getInstance(MESSAGE_DIGEST_NAME);
     }
   }
-
-  @Override
-  public void initialize() throws NoSuchAlgorithmException{
-    messageDigestInstance = MessageDigest.getInstance(MESSAGE_DIGEST_NAME);
-  }
-
 }


### PR DESCRIPTION
This PR resolves #52 and includes the following updates:

1. A new interface, `HasherFactory`, should be introduced that has a single method, `createHasher()`
2. The map in `BagitChecksumNameMapping` should be changed to hold `HasherFactories`
3. A new `DefaultHasher` class should be introduced that implements `Hasher` and includes the hashing logic from `StandardHasher`
4. The `StandardHasher` enum should be changed to implement `HasherFactory` and return new `DefaultHasher` instances
5. When `BagitChecksumNameMapping.get()` is called, the `HasherFactory` is retrieved from the map and `createHasher()` is called on it and returned

My goal was to make the changes transparent as far as the application is concerned. The main difference leaks out in that a `HasherFactory` is not required when registering a new algorithm.

I had to make a few unrelated changes in `FetchReader` to make PMD happy. Additionally, PMD still fails with the following:

```
1 	src/main/java/com/github/jscancella/hash/DefaultHasher.java 	20 	You shouldnt declare field of MessageDigest type, because unsynchronized access could cause problems
```

So, PMD does not like the `MessageDigest` as an instance variable. This was the root of the original bug, but it is not longer an problem based on how the `Hasher` is used in bagging. It's up to you what you want to do about this warning.