### PR TITLE
Only newline, carriage returns, and % should be percent encoded

### DIFF
--- a/src/main/java/com/github/jscancella/reader/internal/TagFileReader.java
+++ b/src/main/java/com/github/jscancella/reader/internal/TagFileReader.java
@@ -2,7 +2,6 @@ package com.github.jscancella.reader.internal;
 
 import java.net.URI;
 import java.net.URISyntaxException;
-import java.net.URLDecoder;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -81,7 +80,7 @@ public enum TagFileReader {;//using enum to enforce singleton
   protected static String decodeFilname(final String encoded, final Version version, final Charset charset){
     String decoded = encoded.replaceAll("%0A", "\n").replaceAll("%0D", "\r");
     if(version.isSameOrNewer(Version.VERSION_1_0())) {
-      decoded = URLDecoder.decode(encoded, charset);
+      decoded = decoded.replaceAll("%25", "%");
     }
     logger.debug(messages.getString("percent_encoded"), encoded, decoded);
     return decoded;

--- a/src/main/java/com/github/jscancella/writer/internal/RelativePathWriter.java
+++ b/src/main/java/com/github/jscancella/writer/internal/RelativePathWriter.java
@@ -1,6 +1,5 @@
 package com.github.jscancella.writer.internal;
 
-import java.net.URLEncoder;
 import java.nio.charset.Charset;
 import java.nio.file.Path;
 import java.util.ResourceBundle;
@@ -37,11 +36,12 @@ public enum RelativePathWriter { ; // enforce singleton
    * @return percent encoded path
    */
   public static String encodeFilename(final Path path, final Version version, final Charset charset) {
-    String encodedPath = URLEncoder.encode(path.toString(), charset).replace("+", "%20").replace("%5C", "/").replace("%2F", "/");
-    if(version.isOlder(Version.VERSION_1_0())) {
-      encodedPath = path.toString().replaceAll("\n", "%0A").replaceAll("\r", "%0D");
+    String encodedPath = path.toString();
+    if(version.isSameOrNewer(Version.VERSION_1_0())) {
+      encodedPath = encodedPath.replaceAll("%", "%25");
     }
-    logger.debug(messages.getString("encoded_path"), path.toString(), encodedPath);
+    encodedPath = encodedPath.replaceAll("\n", "%0A").replaceAll("\r", "%0D");
+    logger.debug(messages.getString("encoded_path"), path, encodedPath);
     return encodedPath;
   }
 

--- a/src/test/java/com/github/jscancella/reader/internal/TagFileReaderTest.java
+++ b/src/test/java/com/github/jscancella/reader/internal/TagFileReaderTest.java
@@ -1,6 +1,5 @@
 package com.github.jscancella.reader.internal;
 
-import java.net.URLEncoder;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Path;
 import java.nio.file.Paths;
@@ -74,7 +73,7 @@ public class TagFileReaderTest {
   @Test
   public void testPercentDecode() throws Exception{
     String percentEncodedPath = "data/foo%0Afile%0Dnon%25sense%09something.txt";
-    String expectedPath = "data/foo\nfile\rnon%sense\tsomething.txt"; //test a newline, carriage return, tab, and the % sign which is used for percent encoding 
+    String expectedPath = "data/foo\nfile\rnon%sense%09something.txt"; //test a newline, carriage return, and the % sign which is used for percent encoding
     String actualPath = TagFileReader.decodeFilname(percentEncodedPath, Version.VERSION_1_0(), StandardCharsets.UTF_8);
     Assertions.assertEquals(expectedPath, actualPath);
   }


### PR DESCRIPTION
Per the [BagIt 1.0 spec](https://datatracker.ietf.org/doc/html/rfc8493) in manifest files the only characters that should be encoded in file paths are `%`, `\r`, and `\n`:

> If a _filepath_ includes a Line Feed (LF), a Carriage Return (CR),
      a Carriage-Return Line Feed (CRLF), or a percent sign (%), those
      characters (and only those) MUST be percent-encoded following
      [[RFC3986](https://datatracker.ietf.org/doc/html/rfc3986)].

The recent percent-encoding commits are a bit overzealous and encode more than the spec calls for. This pull request just scales back the percent encoding to only handle the three as mentioned in the spec.